### PR TITLE
Simplify by overriding haskellPackages directly

### DIFF
--- a/development.nix
+++ b/development.nix
@@ -1,14 +1,6 @@
 { compiler ? "ghc802" }:
 
 let
-  overlay = self: super: {
-    haskell.packages."${compiler}" = super.haskell.packages."${compiler}".override {
-      overrides = new: old: {
-        haskell-project-template = old.callPackage ./. { };
-      };
-    };
-  };
-
   bootstrap = import <nixpkgs> { };
 
   nixpkgs = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
@@ -17,9 +9,13 @@ let
     inherit (nixpkgs) owner repo rev sha256 fetchSubmodules;
   };
 
-  pkgs = import src { overlays = [ overlay ]; };
+  pkgs = import src { };
 
-  haskellPackages = pkgs.haskell.packages."${compiler}";
+  haskellPackages = pkgs.haskell.packages."${compiler}".override {
+    overrides = new: old: {
+      haskell-project-template = old.callPackage ./. { };
+    };
+  };
 
   # Specifying ghc packages this way ensures that ghc-pkg can see our packages
   ghcAndPackages = haskellPackages.ghcWithPackages (self : [

--- a/development.nix
+++ b/development.nix
@@ -1,18 +1,10 @@
 { compiler ? "ghc802" }:
 
 let
-  overrides = pkgs: haskellPackagesNew: haskellPackagesOld: rec {
-    haskell-project-template = haskellPackagesNew.callPackage ./. { };
-  };
-
-  config = {
-    packageOverrides = pkgs: rec {
-      haskell = pkgs.haskell // {
-        packages = pkgs.haskell.packages // {
-          "${compiler}" = pkgs.haskell.packages."${compiler}".override {
-            overrides = overrides pkgs;
-          };
-        };
+  overlay = self: super: {
+    haskell.packages."${compiler}" = super.haskell.packages."${compiler}".override {
+      overrides = new: old: {
+        haskell-project-template = old.callPackage ./. { };
       };
     };
   };
@@ -25,7 +17,7 @@ let
     inherit (nixpkgs) owner repo rev sha256 fetchSubmodules;
   };
 
-  pkgs = import src { inherit config; };
+  pkgs = import src { overlays = [ overlay ]; };
 
   haskellPackages = pkgs.haskell.packages."${compiler}";
 

--- a/docker-image.nix
+++ b/docker-image.nix
@@ -1,16 +1,6 @@
 { compiler ? "ghc802" }:
 
 let
-  overlay = self: super: {
-    haskell.packages."${compiler}" = super.haskell.packages."${compiler}".override {
-      overrides = new: old: {
-        haskell-project-template =
-          super.haskell.lib.justStaticExecutables
-            (old.callPackage ./. { });
-      };
-    };
-  };
-
   bootstrap = import <nixpkgs> { };
 
   nixpkgs = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
@@ -19,9 +9,15 @@ let
     inherit (nixpkgs) owner repo rev sha256 fetchSubmodules;
   };
 
-  pkgs = import src { overlays = [ overlay ]; };
+  pkgs = import src { };
 
-  haskellPackages = pkgs.haskell.packages."${compiler}";
+  haskellPackages = pkgs.haskell.packages."${compiler}".override {
+    overrides = new: old: {
+      haskell-project-template =
+        pkgs.haskell.lib.justStaticExecutables
+          (old.callPackage ./. { });
+    };
+  };
 in
   pkgs.dockerTools.buildImage {
     name = "haskell-project-template-image";

--- a/release.nix
+++ b/release.nix
@@ -1,14 +1,6 @@
 { compiler ? "ghc802" }:
 
 let
-  overlay = self: super: {
-    haskell.packages."${compiler}" = super.haskell.packages."${compiler}".override {
-      overrides = new: old: {
-        haskell-project-template = old.callPackage ./. { };
-      };
-    };
-  };
-
   bootstrap = import <nixpkgs> { };
 
   nixpkgs = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
@@ -17,9 +9,13 @@ let
     inherit (nixpkgs) owner repo rev sha256 fetchSubmodules;
   };
 
-  pkgs = import src { overlays = [ overlay ]; };
+  pkgs = import src { };
 
-  haskellPackages = pkgs.haskell.packages."${compiler}";
+  haskellPackages = pkgs.haskell.packages."${compiler}".override {
+    overrides = new: old: {
+      haskell-project-template = old.callPackage ./. { };
+    };
+  };
 
   # Specifying ghc packages this way ensures that ghc-pkg can see our packages
   ghcAndPackages = haskellPackages.ghcWithPackages (self : [

--- a/release.nix
+++ b/release.nix
@@ -1,18 +1,10 @@
 { compiler ? "ghc802" }:
 
 let
-  overrides = pkgs: haskellPackagesNew: haskellPackagesOld: rec {
-    haskell-project-template = haskellPackagesNew.callPackage ./. { };
-  };
-
-  config = {
-    packageOverrides = pkgs: rec {
-      haskell = pkgs.haskell // {
-        packages = pkgs.haskell.packages // {
-          "${compiler}" = pkgs.haskell.packages."${compiler}".override {
-            overrides = overrides pkgs;
-          };
-        };
+  overlay = self: super: {
+    haskell.packages."${compiler}" = super.haskell.packages."${compiler}".override {
+      overrides = new: old: {
+        haskell-project-template = old.callPackage ./. { };
       };
     };
   };
@@ -25,7 +17,7 @@ let
     inherit (nixpkgs) owner repo rev sha256 fetchSubmodules;
   };
 
-  pkgs = import src { inherit config; };
+  pkgs = import src { overlays = [ overlay ]; };
 
   haskellPackages = pkgs.haskell.packages."${compiler}";
 


### PR DESCRIPTION
I did a quick test with `nix-shell release.nix` and this seems to work the same as the old solution.