### PR TITLE
shellHook touch-ups

### DIFF
--- a/nix/bash-prompt.sh
+++ b/nix/bash-prompt.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-reset_colors='\[$(tput sgr0)\]'
+_build_prompt() {
+  local reset_colors datetime user working_dir git_status line2
 
-datetime="\[$(tput setaf 150)\]\\D{%F %T}"
-user=" \[$(tput setaf 255)\] ❤${name}-nix-shell❤"
-working_dir=" \[$(tput setaf 162)\]\\w"
-git_status="\[$(tput setaf 6)\]\$(__git_ps1)"
-line2="\\n\[$(tput setaf 4)\]λx. ${reset_colors}"
+  reset_colors='\[$(tput sgr0)\]'
 
-export PS1="${datetime}${user}${working_dir}${git_status}${line2}"
-export GIT_PS1_SHOWDIRTYSTATE=1
+  datetime="\[$(tput setaf 150)\]\\D{%F %T}"
+  user=" \[$(tput setaf 255)\] ❤${name}-nix-shell❤"
+  working_dir=" \[$(tput setaf 162)\]\\w"
+  git_status="\[$(tput setaf 6)\]\$(__git_ps1)"
+  line2="\\n\[$(tput setaf 4)\]λx. ${reset_colors}"
+
+  export PS1="${datetime}${user}${working_dir}${git_status}${line2}"
+  export GIT_PS1_SHOWDIRTYSTATE=1
+}
+
+_build_prompt
+unset _build_prompt

--- a/nix/development.nix
+++ b/nix/development.nix
@@ -22,7 +22,7 @@ in
     ];
 
     shellHook = old.shellHook + builtins.readFile ./bash-prompt.sh + ''
-      source ${pkgs.git.out}/etc/bash_completion.d/git-prompt.sh
-      source ${pkgs.git.out}/etc/bash_completion.d/git-completion.bash
+      source ${pkgs.git}/etc/bash_completion.d/git-prompt.sh
+      source ${pkgs.git}/etc/bash_completion.d/git-completion.bash
     '';
   })


### PR DESCRIPTION
- Replace `${pkgs.git.out}` with the equivalent `${pkgs.git}`
- Refactor bash-prompt.sh to avoid leaking extra variables into the environment